### PR TITLE
New Themes Added

### DIFF
--- a/Themes/Andromeda Bordered.xccolortheme
+++ b/Themes/Andromeda Bordered.xccolortheme
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.10939867794513702 0.1230933666229248 0.15309345722198486 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.13277998566627502 0.14685876667499542 0.1853862851858139 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 1.0 1.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.1472807377576828 0.16561730206012726 0.20882025361061096 1.0</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.17805299162864685 0.20105236768722534 0.2578960061073303 1.0</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.803512692451477 0.7605889439582825 0.8204293847084045 1.0</string>
+		<key>xcode.syntax.character</key>
+		<string>0.9994896054267883 0.21068555116653442 0.16251426935195923 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.9994896054267883 0.21068555116653442 0.16251426935195923 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.9994896054267883 0.21068555116653442 0.16251426935195923 1.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.0 0.9261969327926636 0.72169429063797 1.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.0 0.9261969327926636 0.72169429063797 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.0 0.9261969327926636 0.72169429063797 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.7973541021347046 0.08284889161586761 0.9497063159942627 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.803512692451477 0.7605889439582825 0.8204293847084045 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.4326392412185669 0.8816418647766113 0.3098558187484741 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Andromeda Italic Bordered.xccolortheme
+++ b/Themes/Andromeda Italic Bordered.xccolortheme
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.10939867794513702 0.1230933666229248 0.15309345722198486 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.13277998566627502 0.14685876667499542 0.1853862851858139 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 1.0 1.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.1472807377576828 0.16561730206012726 0.20882025361061096 1.0</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.17805299162864685 0.20105236768722534 0.2578960061073303 1.0</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.803512692451477 0.7605889439582825 0.8204293847084045 1.0</string>
+		<key>xcode.syntax.character</key>
+		<string>0.9994896054267883 0.21068555116653442 0.16251426935195923 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.9994896054267883 0.21068555116653442 0.16251426935195923 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.9994896054267883 0.21068555116653442 0.16251426935195923 1.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.0 0.9261969327926636 0.72169429063797 1.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.0 0.9261969327926636 0.72169429063797 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.0 0.9261969327926636 0.72169429063797 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.7973541021347046 0.08284889161586761 0.9497063159942627 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.803512692451477 0.7605889439582825 0.8204293847084045 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.4326392412185669 0.8816418647766113 0.3098558187484741 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Andromeda Italic.xccolortheme
+++ b/Themes/Andromeda Italic.xccolortheme
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.1015406996011734 0.11143691092729568 0.1375061720609665 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.13277998566627502 0.14685876667499542 0.1853862851858139 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 1.0 1.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.1472807377576828 0.16561730206012726 0.20882025361061096 1.0</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.17805299162864685 0.20105236768722534 0.2578960061073303 1.0</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.803512692451477 0.7605889439582825 0.8204293847084045 1.0</string>
+		<key>xcode.syntax.character</key>
+		<string>0.9994896054267883 0.21068555116653442 0.16251426935195923 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.9994896054267883 0.21068555116653442 0.16251426935195923 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.9994896054267883 0.21068555116653442 0.16251426935195923 1.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.0 0.9261969327926636 0.72169429063797 1.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.0 0.9261969327926636 0.72169429063797 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.0 0.9261969327926636 0.72169429063797 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.7973541021347046 0.08284889161586761 0.9497063159942627 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.803512692451477 0.7605889439582825 0.8204293847084045 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.4326392412185669 0.8816418647766113 0.3098558187484741 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Andromeda.xccolortheme
+++ b/Themes/Andromeda.xccolortheme
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.1015406996011734 0.11143691092729568 0.1375061720609665 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.13277998566627502 0.14685876667499542 0.1853862851858139 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 1.0 1.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.1472807377576828 0.16561730206012726 0.20882025361061096 1.0</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.17805299162864685 0.20105236768722534 0.2578960061073303 1.0</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.803512692451477 0.7605889439582825 0.8204293847084045 1.0</string>
+		<key>xcode.syntax.character</key>
+		<string>0.9994896054267883 0.21068555116653442 0.16251426935195923 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.9994896054267883 0.21068555116653442 0.16251426935195923 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.9994896054267883 0.21068555116653442 0.16251426935195923 1.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.0 0.9261969327926636 0.72169429063797 1.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.0 0.9261969327926636 0.72169429063797 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.0 0.9261969327926636 0.72169429063797 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.7973541021347046 0.08284889161586761 0.9497063159942627 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.5181887149810791 0.0 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.803512692451477 0.7605889439582825 0.8204293847084045 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>1.0 0.8840451240539551 0.2605205476284027 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.4326392412185669 0.8816418647766113 0.3098558187484741 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.558551549911499 0.5630373954772949 0.5921287536621094 0.8</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Eva Dark Bold.xccolortheme
+++ b/Themes/Eva Dark Bold.xccolortheme
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.11515192687511444 0.12914030253887177 0.1559712439775467 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.13643375039100647 0.14680765569210052 0.18185454607009888 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.4463360905647278 0.33317896723747253 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.297870397567749 0.32444316148757935 0.4965270757675171 1.0</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.22150900959968567 0.4683579206466675 0.9562225341796875 0.34901960784313724</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.5396282076835632 0.5808669328689575 0.6484403610229492 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.7713488936424255 0.35410618782043457 0.8525230884552002 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.4555923342704773 0.5164159536361694 0.7311027646064758 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>1.0 0.23579707741737366 0.6533424854278564 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.8307667970657349 0.2495976686477661 0.884998083114624 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.4463360905647278 0.33317896723747253 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.5396282076835632 0.5808669328689575 0.6484403610229492 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.266757994890213 0.5041952729225159 0.9492592811584473 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Eva Dark Italic.xccolortheme
+++ b/Themes/Eva Dark Italic.xccolortheme
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.11515192687511444 0.12914030253887177 0.1559712439775467 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.13643375039100647 0.14680765569210052 0.18185454607009888 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.4463360905647278 0.33317896723747253 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.297870397567749 0.32444316148757935 0.4965270757675171 1.0</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.22150900959968567 0.4683579206466675 0.9562225341796875 0.34901960784313724</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.5396282076835632 0.5808669328689575 0.6484403610229492 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.7713488936424255 0.35410618782043457 0.8525230884552002 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.4555923342704773 0.5164159536361694 0.7311027646064758 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>1.0 0.23579707741737366 0.6533424854278564 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.8307667970657349 0.2495976686477661 0.884998083114624 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.4463360905647278 0.33317896723747253 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.5396282076835632 0.5808669328689575 0.6484403610229492 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.266757994890213 0.5041952729225159 0.9492592811584473 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Eva Dark.xccolortheme
+++ b/Themes/Eva Dark.xccolortheme
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.11515192687511444 0.12914030253887177 0.1559712439775467 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.13643375039100647 0.14680765569210052 0.18185454607009888 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.4463360905647278 0.33317896723747253 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.297870397567749 0.32444316148757935 0.4965270757675171 1.0</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.22150900959968567 0.4683579206466675 0.9562225341796875 0.34901960784313724</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.5396282076835632 0.5808669328689575 0.6484403610229492 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.7713488936424255 0.35410618782043457 0.8525230884552002 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.4555923342704773 0.5164159536361694 0.7311027646064758 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>1.0 0.23579707741737366 0.6533424854278564 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.8307667970657349 0.2495976686477661 0.884998083114624 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.4463360905647278 0.33317896723747253 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.5396282076835632 0.5808669328689575 0.6484403610229492 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.266757994890213 0.5041952729225159 0.9492592811584473 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Eva Light Bold.xccolortheme
+++ b/Themes/Eva Light Bold.xccolortheme
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.8992164134979248 0.9163294434547424 0.9541712999343872 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.8608139753341675 0.8777425289154053 0.9151843786239624 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.3868899941444397 0.2277502864599228 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.6423238515853882 0.6421671509742737 0.6471943855285645 1.0</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.0 0.287923663854599 1.0 0.24705882352941178</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.2925705015659332 0.2923106253147125 0.3005859851837158 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.8239723443984985 0.2498718798160553 0.32859736680984497 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.7713488936424255 0.35410618782043457 0.8525230884552002 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.8239723443984985 0.2498718798160553 0.32859736680984497 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.8239723443984985 0.2498718798160553 0.32859736680984497 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.45901620388031006 0.45901620388031006 0.45901620388031006 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.9869339466094971 0.42510974407196045 0.8304013013839722 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.8072852492332458 0.0 0.7563905715942383 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.27927660942077637 0.0 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.2925705015659332 0.2923106253147125 0.3005859851837158 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.8239723443984985 0.2498718798160553 0.32859736680984497 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.13671404123306274 0.38519367575645447 0.9495677947998047 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Eva Light Italic.xccolortheme
+++ b/Themes/Eva Light Italic.xccolortheme
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.8992164134979248 0.9163294434547424 0.9541712999343872 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.8608139753341675 0.8777425289154053 0.9151843786239624 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.3868899941444397 0.2277502864599228 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.6423238515853882 0.6421671509742737 0.6471943855285645 1.0</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.0 0.287923663854599 1.0 0.24705882352941178</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.2925705015659332 0.2923106253147125 0.3005859851837158 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.8239723443984985 0.2498718798160553 0.32859736680984497 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.7713488936424255 0.35410618782043457 0.8525230884552002 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.8239723443984985 0.2498718798160553 0.32859736680984497 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.8239723443984985 0.2498718798160553 0.32859736680984497 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.45901620388031006 0.45901620388031006 0.45901620388031006 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.9869339466094971 0.42510974407196045 0.8304013013839722 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.8072852492332458 0.0 0.7563905715942383 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.27927660942077637 0.0 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.2925705015659332 0.2923106253147125 0.3005859851837158 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.8239723443984985 0.2498718798160553 0.32859736680984497 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.13671404123306274 0.38519367575645447 0.9495677947998047 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Eva Light.xccolortheme
+++ b/Themes/Eva Light.xccolortheme
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.8992164134979248 0.9163294434547424 0.9541712999343872 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.8608139753341675 0.8777425289154053 0.9151843786239624 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.3868899941444397 0.2277502864599228 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.6423238515853882 0.6421671509742737 0.6471943855285645 1.0</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.0 0.287923663854599 1.0 0.24705882352941178</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.2925705015659332 0.2923106253147125 0.3005859851837158 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.8239723443984985 0.2498718798160553 0.32859736680984497 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.7713488936424255 0.35410618782043457 0.8525230884552002 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.8239723443984985 0.2498718798160553 0.32859736680984497 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.8239723443984985 0.2498718798160553 0.32859736680984497 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.45901620388031006 0.45901620388031006 0.45901620388031006 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.9869339466094971 0.42510974407196045 0.8304013013839722 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.8072852492332458 0.0 0.7563905715942383 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.27927660942077637 0.0 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.2925705015659332 0.2923106253147125 0.3005859851837158 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.8239723443984985 0.2498718798160553 0.32859736680984497 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.13671404123306274 0.38519367575645447 0.9495677947998047 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Material-Theme-Darker-High-Contrast.xccolortheme
+++ b/Themes/Material-Theme-Darker-High-Contrast.xccolortheme
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.09773455560207367 0.09773455560207367 0.09773455560207367 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.0 0.0 0.0 0.3137254901960784</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.7525629997253418 0.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.899844229221344 1.0 1.0 0.25098039215686274</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.307258665561676 0.307258665561676 0.307258665561676 0.3137254901960784</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.899844229221344 1.0 1.0 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.2254677712917328 0.2254677712917328 0.2254677712917328 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.2254677712917328 0.2254677712917328 0.2254677712917328 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.2254677712917328 0.2254677712917328 0.2254677712917328 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.3943036198616028 0.5941120982170105 1.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>1.0 0.7435588240623474 0.2741052210330963 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>1.0 0.4968317449092865 0.6080464720726013 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.6129982471466064 0.7613009214401245 0.8082782030105591 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>1.0 0.3023245334625244 0.3828031122684479 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.358991801738739 0.8490763902664185 1.0 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.2254677712917328 0.2254677712917328 0.2254677712917328 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.43219202756881714 0.31860047578811646 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.899844229221344 1.0 1.0 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.6778011322021484 0.9107239246368408 0.43094080686569214 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.2254677712917328 0.2254677712917328 0.2254677712917328 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Material-Theme-Darker.xccolortheme
+++ b/Themes/Material-Theme-Darker.xccolortheme
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.09773455560207367 0.09773455560207367 0.09773455560207367 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.0 0.0 0.0 0.3137254901960784</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.7525629997253418 0.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.899844229221344 1.0 1.0 0.25098039215686274</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.307258665561676 0.307258665561676 0.307258665561676 0.3137254901960784</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.899844229221344 1.0 1.0 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.26025089621543884 0.26025089621543884 0.26025089621543884 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.26025089621543884 0.26025089621543884 0.26025089621543884 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.26025089621543884 0.26025089621543884 0.26025089621543884 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.3943036198616028 0.5941120982170105 1.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>1.0 0.7435588240623474 0.2741052210330963 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>1.0 0.4968317449092865 0.6080464720726013 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.6129982471466064 0.7613009214401245 0.8082782030105591 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>1.0 0.3023245334625244 0.3828031122684479 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.358991801738739 0.8490763902664185 1.0 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.26025089621543884 0.26025089621543884 0.26025089621543884 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.43219202756881714 0.31860047578811646 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.899844229221344 1.0 1.0 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.6778011322021484 0.9107239246368408 0.43094080686569214 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.26025089621543884 0.26025089621543884 0.26025089621543884 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Material-Theme-Deepforest-High-Contrast.xccolortheme
+++ b/Themes/Material-Theme-Deepforest-High-Contrast.xccolortheme
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.05667898803949356 0.09412603080272675 0.08674649894237518 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.0 0.0 0.0 0.3137254901960784</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.7525629997253418 0.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.6655917167663574 0.9286088943481445 0.7792553901672363 0.25098039215686274</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.29258808493614197 0.6692200303077698 0.406915545463562 0.3137254901960784</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.6655917167663574 0.9286088943481445 0.7792553901672363 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.1917942464351654 0.3226088881492615 0.24859431385993958 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.1917942464351654 0.3226088881492615 0.24859431385993958 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.1917942464351654 0.3226088881492615 0.24859431385993958 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.30915459990501404 0.5584761500358582 0.8646717071533203 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>1.0 0.7435588240623474 0.2741052210330963 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.8325985670089722 0.4886894226074219 0.5348412990570068 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.4757503867149353 0.687832236289978 0.6905120015144348 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>1.0 0.3023245334625244 0.3828031122684479 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.27081260085105896 0.7574499249458313 0.8532480001449585 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.1917942464351654 0.3226088881492615 0.24859431385993958 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>0.8026086091995239 0.4375380873680115 0.31068262457847595 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.6655917167663574 0.9286088943481445 0.7792553901672363 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.6778011322021484 0.9107239246368408 0.43094080686569214 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.1917942464351654 0.3226088881492615 0.24859431385993958 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Material-Theme-Deepforest.xccolortheme
+++ b/Themes/Material-Theme-Deepforest.xccolortheme
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.05667898803949356 0.09412603080272675 0.08674649894237518 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.0 0.0 0.0 0.3137254901960784</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.7525629997253418 0.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.6655917167663574 0.9286088943481445 0.7792553901672363 0.25098039215686274</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.29258808493614197 0.6692200303077698 0.406915545463562 0.3137254901960784</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.6655917167663574 0.9286088943481445 0.7792553901672363 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.1917942464351654 0.3226088881492615 0.24859431385993958 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.1917942464351654 0.3226088881492615 0.24859431385993958 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.1917942464351654 0.3226088881492615 0.24859431385993958 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.30915459990501404 0.5584761500358582 0.8646717071533203 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>1.0 0.7435588240623474 0.2741052210330963 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.8325985670089722 0.4886894226074219 0.5348412990570068 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.4757503867149353 0.687832236289978 0.6905120015144348 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>1.0 0.3023245334625244 0.3828031122684479 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.27081260085105896 0.7574499249458313 0.8532480001449585 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.1917942464351654 0.3226088881492615 0.24859431385993958 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>0.8026086091995239 0.4375380873680115 0.31068262457847595 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.6655917167663574 0.9286088943481445 0.7792553901672363 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.6778011322021484 0.9107239246368408 0.43094080686569214 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.1917942464351654 0.3226088881492615 0.24859431385993958 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Material-Theme-Default-High-Contrast.xccolortheme
+++ b/Themes/Material-Theme-Default-High-Contrast.xccolortheme
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.10379403829574585 0.1489320695400238 0.1683860868215561 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.0 0.0 0.0 0.3137254901960784</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.7525629997253418 0.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.899844229221344 1.0 1.0 0.25098039215686274</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.3385418653488159 0.770133376121521 0.7205978631973267 0.12549019607843137</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.899844229221344 1.0 1.0 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.23816104233264923 0.36010217666625977 0.40835145115852356 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.23816104233264923 0.36010217666625977 0.40835145115852356 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.23816104233264923 0.36010217666625977 0.40835145115852356 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.3943036198616028 0.5941120982170105 1.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>1.0 0.7435588240623474 0.2741052210330963 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>1.0 0.4968317449092865 0.6080464720726013 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.6129982471466064 0.7613009214401245 0.8082782030105591 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>1.0 0.3023245334625244 0.3828031122684479 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.358991801738739 0.8490763902664185 1.0 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.23816104233264923 0.36010217666625977 0.40835145115852356 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.43219202756881714 0.31860047578811646 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.899844229221344 1.0 1.0 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.6778011322021484 0.9107239246368408 0.43094080686569214 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.23816104233264923 0.36010217666625977 0.40835145115852356 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Material-Theme-Default.xccolortheme
+++ b/Themes/Material-Theme-Default.xccolortheme
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.10379403829574585 0.1489320695400238 0.1683860868215561 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.0 0.0 0.0 0.3137254901960784</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.7525629997253418 0.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.899844229221344 1.0 1.0 0.25098039215686274</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.3385418653488159 0.770133376121521 0.7205978631973267 0.12549019607843137</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.899844229221344 1.0 1.0 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.23816104233264923 0.36010217666625977 0.40835145115852356 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.23816104233264923 0.36010217666625977 0.40835145115852356 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.23816104233264923 0.36010217666625977 0.40835145115852356 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.3943036198616028 0.5941120982170105 1.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>1.0 0.7435588240623474 0.2741052210330963 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>1.0 0.4968317449092865 0.6080464720726013 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.6129982471466064 0.7613009214401245 0.8082782030105591 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>1.0 0.3023245334625244 0.3828031122684479 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.358991801738739 0.8490763902664185 1.0 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.23816104233264923 0.36010217666625977 0.40835145115852356 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.43219202756881714 0.31860047578811646 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.899844229221344 1.0 1.0 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.6778011322021484 0.9107239246368408 0.43094080686569214 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.23816104233264923 0.36010217666625977 0.40835145115852356 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Material-Theme-Lighter-High-Contrast.xccolortheme
+++ b/Themes/Material-Theme-Lighter-High-Contrast.xccolortheme
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>1.0 1.0 1.0 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.7453322410583496 0.8097078204154968 0.8231521844863892 0.3137254901960784</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>0.1147054135799408 0.1147054135799408 0.1147054135799408 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 0.25098039215686274</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.3385418653488159 0.770133376121521 0.7205978631973267 0.25098039215686274</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.2765571177005768 0.43194258213043213 0.6844582557678223 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.9146876931190491 0.4834512770175934 0.0 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>1.0 0.11800354719161987 0.35258519649505615 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.4418363571166992 0.5164582133293152 0.6397165656089783 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.9587337374687195 0.0 0.12014947831630707 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.0 0.6353007555007935 0.6596403121948242 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.283303827047348 0.16920700669288635 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.45898932218551636 0.6856353282928467 0.22352854907512665 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Material-Theme-Lighter.xccolortheme
+++ b/Themes/Material-Theme-Lighter.xccolortheme
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.9752962589263916 0.975296139717102 0.975296139717102 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.7453322410583496 0.8097078204154968 0.8231521844863892 0.3137254901960784</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>0.1147054135799408 0.1147054135799408 0.1147054135799408 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 0.25098039215686274</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.3385418653488159 0.770133376121521 0.7205978631973267 0.25098039215686274</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.2765571177005768 0.43194258213043213 0.6844582557678223 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.9146876931190491 0.4834512770175934 0.0 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>1.0 0.11800354719161987 0.35258519649505615 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.4418363571166992 0.5164582133293152 0.6397165656089783 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.9587337374687195 0.0 0.12014947831630707 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.0 0.6353007555007935 0.6596403121948242 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.283303827047348 0.16920700669288635 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.45898932218551636 0.6856353282928467 0.22352854907512665 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.4740830957889557 0.5803970098495483 0.6255584359169006 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Material-Theme-Ocean-High-Contrast.xccolortheme
+++ b/Themes/Material-Theme-Ocean-High-Contrast.xccolortheme
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.05033036693930626 0.05545780062675476 0.0807739645242691 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.0 0.0 0.0 0.3137254901960784</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.7525629997253418 0.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.6697410345077515 0.6879936456680298 0.8224344253540039 0.25098039215686274</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.3581199645996094 0.40263909101486206 0.6660457849502563 0.3137254901960784</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.6697410345077515 0.6879936456680298 0.8224344253540039 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.20832446217536926 0.2273545265197754 0.2982791066169739 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.20832446217536926 0.2273545265197754 0.2982791066169739 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.20832446217536926 0.2273545265197754 0.2982791066169739 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.3943036198616028 0.5941120982170105 1.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>1.0 0.7435588240623474 0.2741052210330963 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>1.0 0.4968317449092865 0.6080464720726013 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.6129982471466064 0.7613009214401245 0.8082782030105591 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>1.0 0.3023245334625244 0.3828031122684479 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.358991801738739 0.8490763902664185 1.0 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.20832446217536926 0.2273545265197754 0.2982791066169739 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.43219202756881714 0.31860047578811646 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.6697410345077515 0.6879936456680298 0.8224344253540039 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.6778011322021484 0.9107239246368408 0.43094080686569214 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.20832446217536926 0.2273545265197754 0.2982791066169739 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Material-Theme-Ocean.xccolortheme
+++ b/Themes/Material-Theme-Ocean.xccolortheme
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.05033036693930626 0.05545780062675476 0.0807739645242691 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.0 0.0 0.0 0.3137254901960784</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.7525629997253418 0.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.6697410345077515 0.6879936456680298 0.8224344253540039 0.25098039215686274</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.3581199645996094 0.40263909101486206 0.6660457849502563 0.3137254901960784</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.6697410345077515 0.6879936456680298 0.8224344253540039 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.20832446217536926 0.2273545265197754 0.2982791066169739 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.20832446217536926 0.2273545265197754 0.2982791066169739 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.20832446217536926 0.2273545265197754 0.2982791066169739 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.3943036198616028 0.5941120982170105 1.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>1.0 0.7435588240623474 0.2741052210330963 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>1.0 0.4968317449092865 0.6080464720726013 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.6129982471466064 0.7613009214401245 0.8082782030105591 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>1.0 0.3023245334625244 0.3828031122684479 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.358991801738739 0.8490763902664185 1.0 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.20832446217536926 0.2273545265197754 0.2982791066169739 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.43219202756881714 0.31860047578811646 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.6697410345077515 0.6879936456680298 0.8224344253540039 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.6778011322021484 0.9107239246368408 0.43094080686569214 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.20832446217536926 0.2273545265197754 0.2982791066169739 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Material-Theme-Palenight-High-Contrast.xccolortheme
+++ b/Themes/Material-Theme-Palenight-High-Contrast.xccolortheme
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.11795869469642639 0.13079224526882172 0.18999525904655457 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.0 0.0 0.0 0.3137254901960784</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.7525629997253418 0.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.6697410345077515 0.6879936456680298 0.8224344253540039 0.25098039215686274</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.3581199645996094 0.40263909101486206 0.6660457849502563 0.3137254901960784</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.6697410345077515 0.6879936456680298 0.8224344253540039 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.32379767298698425 0.3509749472141266 0.5259822010993958 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.32379767298698425 0.3509749472141266 0.5259822010993958 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.32379767298698425 0.3509749472141266 0.5259822010993958 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.3943036198616028 0.5941120982170105 1.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>1.0 0.7435588240623474 0.2741052210330963 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>1.0 0.4968317449092865 0.6080464720726013 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.6129982471466064 0.7613009214401245 0.8082782030105591 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>1.0 0.3023245334625244 0.3828031122684479 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.358991801738739 0.8490763902664185 1.0 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.32379767298698425 0.3509749472141266 0.5259822010993958 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.43219202756881714 0.31860047578811646 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.6697410345077515 0.6879936456680298 0.8224344253540039 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.6778011322021484 0.9107239246368408 0.43094080686569214 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.32379767298698425 0.3509749472141266 0.5259822010993958 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Material-Theme-Palenight.xccolortheme
+++ b/Themes/Material-Theme-Palenight.xccolortheme
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.11795869469642639 0.13079224526882172 0.18999525904655457 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.0 0.0 0.0 0.3137254901960784</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.7525629997253418 0.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.6697410345077515 0.6879936456680298 0.8224344253540039 0.25098039215686274</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.3581199645996094 0.40263909101486206 0.6660457849502563 0.3137254901960784</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.6697410345077515 0.6879936456680298 0.8224344253540039 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.32379767298698425 0.3509749472141266 0.5259822010993958 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.32379767298698425 0.3509749472141266 0.5259822010993958 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.32379767298698425 0.3509749472141266 0.5259822010993958 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.3943036198616028 0.5941120982170105 1.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>1.0 0.7435588240623474 0.2741052210330963 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>1.0 0.4968317449092865 0.6080464720726013 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.6129982471466064 0.7613009214401245 0.8082782030105591 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>1.0 0.3023245334625244 0.3828031122684479 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.358991801738739 0.8490763902664185 1.0 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.32379767298698425 0.3509749472141266 0.5259822010993958 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.43219202756881714 0.31860047578811646 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.6697410345077515 0.6879936456680298 0.8224344253540039 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.6778011322021484 0.9107239246368408 0.43094080686569214 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.32379767298698425 0.3509749472141266 0.5259822010993958 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Omni.xccolortheme
+++ b/Themes/Omni.xccolortheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.07755549252033234 0.0665157362818718 0.10302159935235977 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.09727492183446884 0.07806295901536942 0.1361672282218933 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>0.0 0.0 0.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>1.0 1.0 1.0 0.10196078431372549</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.1951623260974884 0.19361555576324463 0.23931795358657837 1.0</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.8540924191474915 0.8532418608665466 0.8802924156188965 1.0</string>
+		<key>xcode.syntax.character</key>
+		<string>0.27932658791542053 0.7964977025985718 0.865946352481842 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.29047292470932007 0.21446815133094788 0.4452696740627289 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>1.0 0.31075990200042725 0.7430192828178406 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>1.0 0.31075990200042725 0.7430192828178406 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.090916208922863 0.9079951047897339 0.3786225914955139 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.5346786379814148 0.4552965462207794 0.7527651190757751 1.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>0.27932658791542053 0.7964977025985718 0.865946352481842 1.0</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>0.27932658791542053 0.7964977025985718 0.865946352481842 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.27932658791542053 0.7964977025985718 0.865946352481842 1.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.8540924191474915 0.8532418608665466 0.8802924156188965 1.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>0.090916208922863 0.9079951047897339 0.3786225914955139 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.5346786379814148 0.4552965462207794 0.7527651190757751 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.5346786379814148 0.4552965462207794 0.7527651190757751 1.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>0.27932658791542053 0.7964977025985718 0.865946352481842 1.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.8540924191474915 0.8532418608665466 0.8802924156188965 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.27932658791542053 0.7964977025985718 0.865946352481842 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>1.0 0.31075990200042725 0.7430192828178406 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>1.0 0.31075990200042725 0.7430192828178406 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>0.27932658791542053 0.7964977025985718 0.865946352481842 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.8540924191474915 0.8532418608665466 0.8802924156188965 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.5346786379814148 0.4552965462207794 0.7527651190757751 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.8917480707168579 0.8497872352600098 0.3340361714363098 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>1.0 0.31075990200042725 0.7430192828178406 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/OneDark.xccolortheme
+++ b/Themes/OneDark.xccolortheme
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.11515192687511444 0.12914030253887177 0.1559712439775467 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.4958493113517761 0.6729579567909241 1.0 0.0392156862745098</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>0.18729722499847412 0.4548310339450836 1.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.6008396148681641 0.6376963257789612 0.701924741268158 0.14901960784313725</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.1813056766986847 0.2046952098608017 0.25384995341300964 1.0</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.6008396148681641 0.6376963257789612 0.701924741268158 1.0</string>
+		<key>xcode.syntax.character</key>
+		<string>0.8194451332092285 0.5206174254417419 0.29239314794540405 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.28363534808158875 0.3143961429595947 0.36858320236206055 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.28363534808158875 0.3143961429595947 0.36858320236206055 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.28363534808158875 0.3143961429595947 0.36858320236206055 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.2071722447872162 0.6284995079040527 0.9487926959991455 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.9039760231971741 0.6968550086021423 0.3642963171005249 1.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>0.8194451332092285 0.5206174254417419 0.29239314794540405 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.9039760231971741 0.6968550086021423 0.3642963171005249 1.0</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>0.8194451332092285 0.5206174254417419 0.29239314794540405 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.8194451332092285 0.5206174254417419 0.29239314794540405 1.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>0.11545718461275101 0.6732983589172363 0.7194551229476929 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.9039760231971741 0.6968550086021423 0.3642963171005249 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.9039760231971741 0.6968550086021423 0.3642963171005249 1.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>0.8194451332092285 0.5206174254417419 0.29239314794540405 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.11545718461275101 0.6732983589172363 0.7194551229476929 1.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.9198123216629028 0.2908492684364319 0.3737461566925049 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.7778373956680298 0.3381134867668152 0.8630421161651611 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.28363534808158875 0.3143961429595947 0.36858320236206055 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>0.8194451332092285 0.5206174254417419 0.29239314794540405 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.6008396148681641 0.6376963257789612 0.701924741268158 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.9039760231971741 0.6968550086021423 0.3642963171005249 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.483247846364975 0.7352218627929688 0.3634161949157715 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.28363534808158875 0.3143961429595947 0.36858320236206055 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Shades of Purple (Super Dark) · BETA.xccolortheme
+++ b/Themes/Shades of Purple (Super Dark) · BETA.xccolortheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.07650040835142136 0.06993799656629562 0.14641162753105164 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.09188129007816315 0.08659319579601288 0.20276081562042236 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.7751545906066895 0.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>1.0 1.0 1.0 0.10196078431372549</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.2970726788043976 0.0 0.5957881808280945 0.5333333333333333</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>1.0 1.0 1.0 1.0</string>
+		<key>xcode.syntax.character</key>
+		<string>1.0 0.20360787212848663 0.47323331236839294 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.689530074596405 0.22228381037712097 1.0 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.689530074596405 0.22228381037712097 1.0 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.689530074596405 0.22228381037712097 1.0 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>1.0 0.7751545906066895 0.0 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.8404430747032166 0.9229075908660889 1.0 1.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>1.0 0.5166469812393188 0.0 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.8404430747032166 0.9229075908660889 1.0 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>1.0 0.5166469812393188 0.0 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.689530074596405 0.22228381037712097 1.0 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.20360787212848663 0.47323331236839294 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>1.0 1.0 1.0 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.4706459641456604 1.0 0.43291521072387695 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.689530074596405 0.22228381037712097 1.0 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Shades of Purple.xccolortheme
+++ b/Themes/Shades of Purple.xccolortheme
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.1330089569091797 0.11849440634250641 0.2737727165222168 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.09188129007816315 0.08659319579601288 0.20276081562042236 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 0.7751545906066895 0.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>1.0 1.0 1.0 0.10196078431372549</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.689530074596405 0.22228381037712097 1.0 0.5333333333333333</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>1.0 1.0 1.0 1.0</string>
+		<key>xcode.syntax.character</key>
+		<string>1.0 0.20360787212848663 0.47323331236839294 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.689530074596405 0.22228381037712097 1.0 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.689530074596405 0.22228381037712097 1.0 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.689530074596405 0.22228381037712097 1.0 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>1.0 0.7751545906066895 0.0 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.8404430747032166 0.9229075908660889 1.0 1.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>1.0 0.5166469812393188 0.0 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>1.0 0.7751545906066895 0.0 1.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.8404430747032166 0.9229075908660889 1.0 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>1.0 0.5166469812393188 0.0 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.689530074596405 0.22228381037712097 1.0 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.20360787212848663 0.47323331236839294 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>1.0 1.0 1.0 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.4255507290363312 1.0 1.0 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.4706459641456604 1.0 0.43291521072387695 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.689530074596405 0.22228381037712097 1.0 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/Winter Is Coming.xccolortheme
+++ b/Themes/Winter Is Coming.xccolortheme
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.0 0.06882109493017197 0.11872256547212601 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.0 0.2139282524585724 0.530039370059967 0.4666666666666667</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>0.0 0.5645681619644165 0.8211436867713928 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.17642228305339813 0.17321762442588806 0.14486722648143768 1.0</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.0 0.14688952267169952 0.32337260246276855 1.0</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.5344175696372986 0.8344730138778687 0.9757413268089294 1.0</string>
+		<key>xcode.syntax.character</key>
+		<string>0.3943036198616028 0.5941120982170105 1.0 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.5296453237533569 0.5296453237533569 0.5296453237533569 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.5296453237533569 0.5296453237533569 0.5296453237533569 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.5296453237533569 0.5296453237533569 0.5296453237533569 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.41477710008621216 0.6204580664634705 0.973609209060669 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.8205578327178955 0.5149840116500854 1.0 1.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>0.4645525813102722 0.6524747610092163 0.9714460372924805 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.303194135427475 0.8501725196838379 0.7446495294570923 1.0</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>0.4645525813102722 0.6524747610092163 0.9714460372924805 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.9638243317604065 0.4990485906600952 0.797285795211792 1.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.5339047312736511 0.7702304124832153 0.9325177669525146 1.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>0.9711348414421082 0.9117075204849243 0.6214973330497742 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.8205578327178955 0.5149840116500854 1.0 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.8205578327178955 0.5149840116500854 1.0 1.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>0.4645525813102722 0.6524747610092163 0.9714460372924805 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.303194135427475 0.8501725196838379 0.7446495294570923 1.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.5339047312736511 0.7702304124832153 0.9325177669525146 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.303194135427475 0.8501725196838379 0.7446495294570923 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.0 0.7104980945587158 0.9982316493988037 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.5296453237533569 0.5296453237533569 0.5296453237533569 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>0.3576330840587616 0.9420192837715149 0.4727686643600464 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.5344175696372986 0.8344730138778687 0.9757413268089294 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.8205578327178955 0.5149840116500854 1.0 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.627771258354187 0.9486255645751953 0.6811463832855225 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.5296453237533569 0.5296453237533569 0.5296453237533569 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/vue-theme-high-contrast.xccolortheme
+++ b/Themes/vue-theme-high-contrast.xccolortheme
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.0 0.12380137294530869 0.15412776172161102 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.0 0.0 0.0 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1.0 1.0 1.0 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.1510991007089615 0.16639824211597443 0.18385547399520874 1.0</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.0 0.0 0.0 1.0</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.8780560493469238 0.8780560493469238 0.878055989742279 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.0 0.7756725549697876 0.8493937253952026 1.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>1.0 0.0 0.25251176953315735 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>1.0 0.6758375763893127 0.35117286443710327 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.36405885219573975 0.8710918426513672 0.9750702381134033 1.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>1.0 0.6758375763893127 0.35117286443710327 0.8901960784313725</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>1.0 0.0 0.25251176953315735 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>1.0 0.6758375763893127 0.35117286443710327 1.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>1.0 0.0 0.25251176953315735 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.5065199136734009 0.8207491636276245 0.8259694576263428 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.0 0.7756725549697876 0.8493937253952026 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.15303072333335876 0.0 0.8705882352941177</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.8780560493469238 0.8780560493469238 0.878055989742279 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.0 0.6697887182235718 1.0 1.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Themes/vue-theme.xccolortheme
+++ b/Themes/vue-theme.xccolortheme
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.0 0.12974920868873596 0.16378150880336761 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.19546298682689667 0.23274502158164978 0.27479442954063416 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>0.9655500650405884 0.9669020771980286 0.9225865602493286 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.1510991007089615 0.16639824211597443 0.18385547399520874 1.0</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.2098717987537384 0.2222108095884323 0.23720237612724304 0.5294117647058824</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.8780560493469238 0.8780560493469238 0.878055989742279 1.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>1.0 0.0 0.3373628854751587 0.9450980392156862</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>1.0 0.7446568608283997 0.47803938388824463 0.9058823529411765</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.33334991335868835 0.7138880491256714 0.7896965146064758 1.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>1.0 0.7446568608283997 0.47803938388824463 0.8901960784313725</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>1.0 0.0 0.3373628854751587 0.9450980392156862</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>1.0 0.7446568608283997 0.47803938388824463 1.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>1.0 0.0 0.3373628854751587 0.9450980392156862</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.5065199136734009 0.8207491636276245 0.8259694576263428 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.0 0.7756725549697876 0.8493937253952026 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>1.0 0.15303072333335876 0.0 0.8705882352941177</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.8780560493469238 0.8780560493469238 0.878055989742279 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.0 0.6259381771087646 0.7191028594970703 0.8549019607843137</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Add new Xcode color themes

This commit introduces a variety of new color themes for Xcode:

- Andromeda (standard, italic, and bordered variants)
- Eva (Dark and Light, with bold and italic variants)
- Material Theme (multiple variants including Default, Darker, Deepforest, 
  Lighter, Ocean, and Palenight, each with high-contrast options)
- Omni
- OneDark
- Shades of Purple (including a "Super Dark" beta version)
- Winter Is Coming
- Vue Theme (standard and high-contrast variants)

Total: 29 new .xccolortheme files added

These themes provide users with a wider range of visual customization 
options for their Xcode development environment.

Note : Screenshots will be added later for these themese 